### PR TITLE
Proper fix for the April 2020 Helix update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ passport.use(new twitchStrategy({
     clientID: TWITCH_CLIENT_ID,
     clientSecret: TWITCH_CLIENT_SECRET,
     callbackURL: "http://127.0.0.1:3000/auth/twitch/callback",
-    scope: "user_read",
-    customHeaders: {
-        'client-id': TWITCH_CLIENT_ID,
-    },
+    scope: "user_read"
   },
   function(accessToken, refreshToken, profile, done) {
     User.findOrCreate({ twitchId: profile.id }, function (err, user) {
@@ -94,10 +91,7 @@ passport.use(new twitchStrategy({
     clientID: "098f6bcd4621d373cade4e832627b4f6",
     clientSecret: "4eb20288afaed97e82bde371260db8d8",
     callbackURL: "http://127.0.0.1:3000/auth/twitch/callback",
-    scope: "user_read",
-    customHeaders: {
-        'client-id': "098f6bcd4621d373cade4e832627b4f6",
-    },
+    scope: "user_read"
   },
   function(accessToken, refreshToken, profile, done) {
     // Suppose we are using mongo..

--- a/oauth2.js
+++ b/oauth2.js
@@ -73,7 +73,7 @@ class Strategy extends OAuth2Strategy {
      * @api protected
      */
     userProfile(accessToken, done) {
-        this._oauth2.get("https://api.twitch.tv/helix/users", token, function (err, body, res) {
+        this._oauth2.get("https://api.twitch.tv/helix/users", accessToken, function (err, body, res) {
             if (err) { return done(new InternalOAuthError("failed to fetch user profile", err)); }
 
             try {

--- a/oauth2.js
+++ b/oauth2.js
@@ -46,6 +46,7 @@ class Strategy extends OAuth2Strategy {
         options = options || {}
         options.authorizationURL = options.authorizationURL || "https://id.twitch.tv/oauth2/authorize"
         options.tokenURL = options.tokenURL || "https://id.twitch.tv/oauth2/token"
+        options.customHeaders = options.customHeaders || {}
         options.customHeaders['Client-ID'] = options.clientID
 
         super(options, verify)

--- a/oauth2.js
+++ b/oauth2.js
@@ -46,7 +46,8 @@ class Strategy extends OAuth2Strategy {
         options = options || {}
         options.authorizationURL = options.authorizationURL || "https://id.twitch.tv/oauth2/authorize"
         options.tokenURL = options.tokenURL || "https://id.twitch.tv/oauth2/token"
-        
+        options.customHeaders['Client-ID'] = options.clientID
+
         super(options, verify)
 
         this.name = "twitch"
@@ -55,7 +56,7 @@ class Strategy extends OAuth2Strategy {
         this._oauth2.setAuthMethod("Bearer")
         this._oauth2.useAuthorizationHeaderforGET(true)
     }
-    
+
     /**
      * Retrieve user profile from Twitch.
      *
@@ -70,10 +71,10 @@ class Strategy extends OAuth2Strategy {
      * @param {Function} done
      * @api protected
      */
-    userProfile(token, done) {
+    userProfile(accessToken, done) {
         this._oauth2.get("https://api.twitch.tv/helix/users", token, function (err, body, res) {
             if (err) { return done(new InternalOAuthError("failed to fetch user profile", err)); }
-    
+
             try {
                 done(null, {
                     ...JSON.parse(body).data[0],


### PR DESCRIPTION
This sends the client ID with the custom headers automatically.

I also reverted the recent documentation change, as the proposed workaround is not necessary anymore.