### PR TITLE
Update dependencies for modern versions

### DIFF
--- a/oauth2.js
+++ b/oauth2.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-var jwt = require('jsonwebtoken')
 var OAuth2Strategy = require("passport-oauth2")
 var InternalOAuthError = OAuth2Strategy.InternalOAuthError
 

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   ],
   "main": "./index.js",
   "dependencies": {
-    "passport-oauth2": "^1.4.0",
-    "pkginfo": "0.2.x"
+    "passport-oauth2": "^1.6.0",
+    "pkginfo": "^0.4.0"
   },
   "devDependencies": {
     "vows": "0.6.x"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   ],
   "main": "./index.js",
   "dependencies": {
-    "jsonwebtoken": "^8.2.1",
     "passport-oauth2": "^1.4.0",
     "pkginfo": "0.2.x"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-twitch-new",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Twitch (OAuth) authentication strategies using the new Twitch API for Passport.",
   "keywords": [
     "passport",
@@ -41,7 +41,7 @@
     "vows": "0.6.x"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.14.0"
   },
   "maintainers": [
     {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "pkginfo": "^0.4.0"
   },
   "devDependencies": {
-    "vows": "0.6.x"
+    "vows": "0.8.x"
   },
   "engines": {
     "node": ">=0.14.0"


### PR DESCRIPTION
This PR should update all the dependencies to more modern versions. 

Primary reason for this PR is a known vulnerability in `jsonwebtoken` which seems to no longer be used by this strategy, and should be removed.

I've only done limited testing in my own personal context, which appears to be working fine. Further testing may be required.